### PR TITLE
stress the existence of an FAQ

### DIFF
--- a/app/views/static/contact.html.erb
+++ b/app/views/static/contact.html.erb
@@ -4,6 +4,9 @@
   <h1>Contact Us</h1>
   <p>Feel free to message us with any bug reports, feature requests, or to contact us for any reason.</p>
   <p>
+    <p>
+      <strong>Please consult the <a href="/faq">FAQ</a> prior to contacting us</strong>.
+    </p>
     <strong>Please Note:</strong> The message will be sent to a private Discord channel, only the team can see.
     If you are not comfortable with your message being sent there, please contact us via email: <strong>dev (at) moxvallix.com</strong>.
   </p>


### PR DESCRIPTION
on the contact page there doesn't seem to be some sort of reference to some sort of FAQ page. Arguably this isn't too important since we don't really receive messages constantly -- this'd be very great for keeping our inboxes happy